### PR TITLE
Hotfix on mcp3208 dev

### DIFF
--- a/mcp3208dev/mcp3208_spi_dev.c
+++ b/mcp3208dev/mcp3208_spi_dev.c
@@ -133,5 +133,7 @@ static void __exit spi_dev_exit(void) {
 }
 
 MODULE_LICENSE("Dual BSD/GPL");
+MODULE_AUTHOR("Peter Park <holy.people@kakao.com>");
+MODULE_DESCRIPTION("MCP3208 SPI Device Driver");
 module_init(spi_dev_init);
 module_exit(spi_dev_exit);

--- a/mcp3208dev/mcp3208_spi_dev.c
+++ b/mcp3208dev/mcp3208_spi_dev.c
@@ -46,7 +46,7 @@ static ssize_t mcp3208_spi_read(struct file *file, char * data, size_t size, lof
     };
 
     DEBUG_MSG("data: %d \n", data[0]);
-    if ( data[0] < 0 || data[0] > 7 )) { /* mcp3208 has only 0-7 channel */
+    if ( data[0] < 0 || data[0] > 7 ) { /* mcp3208 has only 0-7 channel */
         return -EINVAL; /* Invalid argument */
     }
     channel = *data;


### PR DESCRIPTION
on line 38

```c
if ( data[0] < 0 || data[0] > 7 )) { /* mcp3208 has only 0-7 channel */
        return -EINVAL; /* Invalid argument */
    }
```
REPLACE wrong parenthesis
```c
if ( data[0] < 0 || data[0] > 7 ) { /* mcp3208 has only 0-7 channel */
        return -EINVAL; /* Invalid argument */
    }
```